### PR TITLE
Update dependencies in deno.json and deno.lock

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -39,8 +39,8 @@
   "imports": {
     "@std/assert": "jsr:@std/assert@^0.221.0",
     "@std/testing": "jsr:@std/testing@^0.221.0",
-    "@kz/common-types": "jsr:@kz/common-types@0.0.2",
-    "@kz/common-exceptions": "jsr:@kz/common-exceptions"
+    "@kz/common-types": "jsr:@kz/common-types@^0.0.2",
+    "@kz/common-exceptions": "jsr:@kz/common-exceptions@^0.0.1"
   },
   "exclude": [
     ".git",

--- a/deno.lock
+++ b/deno.lock
@@ -2,7 +2,7 @@
   "version": "3",
   "packages": {
     "specifiers": {
-      "jsr:@kz/common-exceptions": "jsr:@kz/common-exceptions@0.0.1",
+      "jsr:@kz/common-exceptions@^0.0.1": "jsr:@kz/common-exceptions@0.0.1",
       "jsr:@kz/common-types@0.0.2": "jsr:@kz/common-types@0.0.2",
       "jsr:@std/assert@^0.221.0": "jsr:@std/assert@0.221.0",
       "jsr:@std/fmt@^0.221.0": "jsr:@std/fmt@0.221.0",
@@ -38,8 +38,8 @@
   "remote": {},
   "workspace": {
     "dependencies": [
-      "jsr:@kz/common-exceptions",
-      "jsr:@kz/common-types@0.0.2",
+      "jsr:@kz/common-exceptions@^0.0.1",
+      "jsr:@kz/common-types@^0.0.2",
       "jsr:@std/assert@^0.221.0",
       "jsr:@std/testing@^0.221.0"
     ]


### PR DESCRIPTION
Previous publishing attempt failed due to jsrMissingConstraint error.

specifier 'jsr:@kz/common-exceptions' is missing a version constraint